### PR TITLE
Multi monitor fix

### DIFF
--- a/xSkillGilded/xSkillGilded/main.cs
+++ b/xSkillGilded/xSkillGilded/main.cs
@@ -10,6 +10,7 @@ using Vintagestory.API.Common;
 using Vintagestory.API.Config;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Server;
+using Vintagestory.Client;
 using Vintagestory.Client.NoObf;
 using Vintagestory.Common;
 using Vintagestory.GameContent;
@@ -417,11 +418,13 @@ namespace xSkillGilded {
             ImGui.PushStyleVar(ImGuiStyleVar.WindowBorderSize, 0);
             ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding,    0);
             ImGui.PushStyleVar(ImGuiStyleVar.FrameRounding,    0);
-
+            
             int windowWidth  = Math.Min(windowBaseWidth,  window.OuterWidthInt  - 128); // 160
             int windowHeight = Math.Min(windowBaseHeight, window.OuterHeightInt - 128); // 160
-            windowX = (int)window.absOffsetX + size.Width / 2 - windowWidth / 2;
-            windowY = (int)window.absOffsetY + size.Height / 2 - windowHeight / 2;
+            
+            OpenTK.Mathematics.Vector2 windowCenter = ((ClientPlatformWindows)ScreenManager.Platform).window.Bounds.Center;
+            windowX = (int)windowCenter.X - windowWidth / 2;
+            windowY = (int)windowCenter.Y - windowHeight / 2;
             
             windowPosX = windowX;
             windowPosY = windowY;

--- a/xSkillGilded/xSkillGilded/main.cs
+++ b/xSkillGilded/xSkillGilded/main.cs
@@ -418,8 +418,8 @@ namespace xSkillGilded {
             ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding,    0);
             ImGui.PushStyleVar(ImGuiStyleVar.FrameRounding,    0);
 
-            int windowWidth  = Math.Min(windowBaseWidth,  (int)window.OuterWidth  - 128); // 160
-            int windowHeight = Math.Min(windowBaseHeight, (int)window.OuterHeight - 128); // 160
+            int windowWidth  = Math.Min(windowBaseWidth,  window.OuterWidthInt  - 128); // 160
+            int windowHeight = Math.Min(windowBaseHeight, window.OuterHeightInt - 128); // 160
             windowX = (int)window.absOffsetX + size.Width / 2 - windowWidth / 2;
             windowY = (int)window.absOffsetY + size.Height / 2 - windowHeight / 2;
             

--- a/xSkillGilded/xSkillGilded/xSkillGilded.csproj
+++ b/xSkillGilded/xSkillGilded/xSkillGilded.csproj
@@ -51,6 +51,7 @@
       <HintPath>..\..\..\ref\xlib.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <PackageReference Include="OpenTK" Version="4.*" />
   </ItemGroup>
 
 <ItemGroup>


### PR DESCRIPTION
**Edit:** See [Quantumheart's comment](https://github.com/Ttanasart-pt/xskills-gilded/pull/1#issuecomment-3429861363) below for a cleaner fix.

---

This commit fixes the issue where the window position is incorrect when opened on a system with multiple monitors where the game was not in the top-left most monitor.

The issue appeared to be that `window.absOffsetX/Y` both always returned 0.

I could not find a way to get the window location within Vintage Story codebase directly but this information can be accessed with OpenTK. As such I had to add a reference to OpenTK.

I suspect there might also be issues with `LevelPopup, EffectBox` but I have not looked into that.

I also replaced `(int)window.OuterWidth` with `window.OuterWidthInt` (and same with height) as I noticed that was an option.

FYI: This has only been tested on Linux as I do not have any other operation systems set up for testing.